### PR TITLE
MotorTest GUI, issue with switching direction

### DIFF
--- a/examples/TMC262MotorTester/processing/TMC262MotorTest/RunConfiguration.pde
+++ b/examples/TMC262MotorTester/processing/TMC262MotorTest/RunConfiguration.pde
@@ -240,12 +240,6 @@ void setCurrent(int current) {
 }
 
 void setDirection(int direction) {
-  if (direction<0) {
-    directionButtons.activate(1);
-  } 
-  else {
-    directionButtons.activate(0);
-  }
   if (!settingStatus) {
     if (direction<0) {
       println("back");


### PR DESCRIPTION
Switching the direction causes an endless(?) loop which hangs the application (sometimes). Stacktraces imply that the code I removed in this commit is the cause, triggering the GUI event notification over and over.

Though, there seems to be a new issue, i.e. without those lines I get a warning during the GUI startup, though, everything seems to work fine after that, even switching the motor direction.
