### PR TITLE
Swapped INT to Long to prevent rolling around error's

### DIFF
--- a/TMC26XStepper.cpp
+++ b/TMC26XStepper.cpp
@@ -108,7 +108,7 @@
  * dir_pin - the pin where the direction pin is connected
  * step_pin - the pin where the step pin is connected
  */
-TMC26XStepper::TMC26XStepper(int number_of_steps, int cs_pin, int dir_pin, int step_pin, unsigned int current, unsigned int resistor)
+TMC26XStepper::TMC26XStepper(long number_of_steps, int cs_pin, int dir_pin, int step_pin, unsigned int current, unsigned int resistor)
 {
 	//we are not started yet
 	started=false;
@@ -226,7 +226,7 @@ unsigned int TMC26XStepper::getSpeed(void) {
   Moves the motor steps_to_move steps.  If the number is negative, 
    the motor moves in the reverse direction.
  */
-char TMC26XStepper::step(int steps_to_move)
+char TMC26XStepper::step(long steps_to_move)
 {  
 	if (this->steps_left==0) {
   		this->steps_left = abs(steps_to_move);  // how many steps to take
@@ -391,7 +391,7 @@ char TMC26XStepper::getStallGuardFilter(void) {
  * any value in between will be mapped to the next smaller value
  * 0 and 1 set the motor in full step mode
  */
-void TMC26XStepper::setMicrosteps(int number_of_steps) {
+void TMC26XStepper::setMicrosteps(long number_of_steps) {
 	long setting_pattern;
 	//poor mans log
 	if (number_of_steps>=256) {

--- a/TMC26XStepper.h
+++ b/TMC26XStepper.h
@@ -165,8 +165,7 @@ class TMC26XStepper {
      * If you give any other value it will be rounded to the next smaller number (3 would give a microstepping of 2).
      * You can always check the current microstepping with getMicrosteps(). 
      */ 
-	void setMicrosteps(long number_of_steps); /* Swapped INT to long
-    
+	void setMicrosteps(long number_of_steps); 
 	/*!
      * \brief returns the effective current number of microsteps selected.
      *
@@ -192,8 +191,7 @@ class TMC26XStepper {
      * You can always verify with isMoving() or even use stop() to stop the motor before giving it new step directions.
      * \sa isMoving(), getStepsLeft(), stop()
      */
-    char step(long number_of_steps); /* Swapped INT to long
-    
+    char step(long number_of_steps); 
     /*!
      * \brief Central movement method, must be called as often as possible in the lopp function and is very fast.
      *
@@ -568,7 +566,7 @@ class TMC26XStepper {
   	unsigned int steps_left;		//the steps the motor has to do to complete the movement
     int direction;        // Direction of rotation
     unsigned long step_delay;    // delay between steps, in ms, based on speed
-    long number_of_steps;      // total number of steps this motor can take - Swapped from INT to LONG
+    long number_of_steps;      // total number of steps this motor can take
     unsigned int speed; // we need to store the current speed in order to change the speed after changing microstepping
     unsigned int resistor; //current sense resitor value in milliohm
         

--- a/TMC26XStepper.h
+++ b/TMC26XStepper.h
@@ -121,7 +121,7 @@ class TMC26XStepper {
      * You can select a different stepping with setMicrosteps() to aa different value.
      * \sa start(), setMicrosteps()
      */
-	TMC26XStepper(int number_of_steps, int cs_pin, int dir_pin, int step_pin, unsigned int current, unsigned int resistor=150);
+	TMC26XStepper(long number_of_steps, int cs_pin, int dir_pin, int step_pin, unsigned int current, unsigned int resistor=150);
 	
     /*!
      * \brief configures and starts the TMC26X stepper driver. Before you called this function the stepper driver is in nonfunctional mode.
@@ -165,7 +165,7 @@ class TMC26XStepper {
      * If you give any other value it will be rounded to the next smaller number (3 would give a microstepping of 2).
      * You can always check the current microstepping with getMicrosteps(). 
      */ 
-	void setMicrosteps(int number_of_steps);
+	void setMicrosteps(long number_of_steps); /* Swapped INT to long
     
 	/*!
      * \brief returns the effective current number of microsteps selected.
@@ -192,7 +192,7 @@ class TMC26XStepper {
      * You can always verify with isMoving() or even use stop() to stop the motor before giving it new step directions.
      * \sa isMoving(), getStepsLeft(), stop()
      */
-    char step(int number_of_steps);
+    char step(long number_of_steps); /* Swapped INT to long
     
     /*!
      * \brief Central movement method, must be called as often as possible in the lopp function and is very fast.
@@ -568,7 +568,7 @@ class TMC26XStepper {
   	unsigned int steps_left;		//the steps the motor has to do to complete the movement
     int direction;        // Direction of rotation
     unsigned long step_delay;    // delay between steps, in ms, based on speed
-    int number_of_steps;      // total number of steps this motor can take
+    long number_of_steps;      // total number of steps this motor can take - Swapped from INT to LONG
     unsigned int speed; // we need to store the current speed in order to change the speed after changing microstepping
     unsigned int resistor; //current sense resitor value in milliohm
         


### PR DESCRIPTION
During debugging if a value of equal over 100000 would be passed using tmc26XStepper.step(X), it would cause the value to go to a negative int. Debugged back to this bit of code, so pushing as a bug fix to help future projects.